### PR TITLE
added logging of cache copy time (resolves #7)

### DIFF
--- a/src/BrefKernel.php
+++ b/src/BrefKernel.php
@@ -80,7 +80,7 @@ abstract class BrefKernel extends Kernel
 
         $this->logToStderr(sprintf(
             'cache directory prepared in %s ms.',
-            number_format((microtime(true) - $startTime) * 1000)
+            number_format((microtime(true) - $startTime) * 1000, 2)
         ));
     }
 

--- a/src/BrefKernel.php
+++ b/src/BrefKernel.php
@@ -51,6 +51,8 @@ abstract class BrefKernel extends Kernel
 
     protected function prepareCacheDir(string $staticCacheDir, string $tempCacheDir): void
     {
+        $startTime = microtime(true);
+
         $filesystem = new Filesystem;
         $filesystem->mkdir($tempCacheDir);
 
@@ -75,5 +77,22 @@ abstract class BrefKernel extends Kernel
             // and copy all other files, i had intermediate problems when linking them
             $filesystem->copy("$staticCacheDir/$item", "$tempCacheDir/$item");
         }
+
+        $this->logToStderr(sprintf(
+            'cache directory prepared in %s ms.',
+            number_format((microtime(true) - $startTime) * 1000)
+        ));
+    }
+
+    /**
+     * This method logs to stderr.
+     *
+     * It must only be used in a lambda environment since all error output will be logged.
+     *
+     * @param string $message The message to log
+     */
+    protected function logToStderr(string $message): void
+    {
+        file_put_contents('php://stderr', date('[c] ') . $message . PHP_EOL, FILE_APPEND);
     }
 }

--- a/src/BrefKernel.php
+++ b/src/BrefKernel.php
@@ -79,7 +79,7 @@ abstract class BrefKernel extends Kernel
         }
 
         $this->logToStderr(sprintf(
-            'cache directory prepared in %s ms.',
+            'Symfony cache directory prepared in %s ms.',
             number_format((microtime(true) - $startTime) * 1000, 2)
         ));
     }


### PR DESCRIPTION
There is now a very simple logging function for the boot time.
The first usage of it is to log how long it takes for the prepareCacheDir method to copy all files to /tmp.

The output looks like this:

    [2020-04-10T15:30:48+02:00] cache directory prepared in 82 ms.

This is also a hint for #6 by telling how long the current implementation takes to copy the cache dir in a small multipage application.
This time is head-on consistent over 3 tests on a 1024mb lambda function.