### PR TITLE
Rename the kernel to "BrefKernel"

### DIFF
--- a/src/BrefKernel.php
+++ b/src/BrefKernel.php
@@ -3,9 +3,9 @@
 namespace Bref\SymfonyBridge;
 
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\HttpKernel\Kernel as BaseKernel;
+use Symfony\Component\HttpKernel\Kernel;
 
-abstract class Kernel extends BaseKernel
+abstract class BrefKernel extends Kernel
 {
     public function isLambda(): bool
     {


### PR DESCRIPTION
This will avoid us having class Kernel extends Kernel extends Kernel implements KernelInterface. 

