### PR TITLE
use overlayfs (resolves #6 and probably #9)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,15 +20,12 @@
     },
     "require": {
         "php": "^7.3",
-        "symfony/filesystem": "^4.4|^5.0",
         "symfony/http-kernel": "^4.4|^5.0"
     },
     "require-dev": {
         "mnapoli/hard-mode": "^0.2.0",
         "phpstan/phpstan": "^0.12.0",
-        "phpunit/phpunit": "^8.0",
-        "symfony/config": "^4.4|^5.0",
-        "symfony/dependency-injection": "^4.4|^5.0"
+        "phpunit/phpunit": "^8.0"
     },
     "config": {
         "sort-packages": true

--- a/src/BrefKernel.php
+++ b/src/BrefKernel.php
@@ -2,7 +2,6 @@
 
 namespace Bref\SymfonyBridge;
 
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Kernel;
 
 abstract class BrefKernel extends Kernel
@@ -15,84 +14,27 @@ abstract class BrefKernel extends Kernel
     /**
      * {@inheritDoc}
      */
-    public function getCacheDir()
-    {
-        if ($this->isLambda()) {
-            return '/tmp/cache/' . $this->environment;
-        }
-
-        return parent::getCacheDir();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getLogDir()
-    {
-        if ($this->isLambda()) {
-            return '/tmp/log/';
-        }
-
-        return parent::getLogDir();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function boot()
     {
-        // When on the lambda, copy the cache dir over to /tmp where it is writable
-        if ($this->isLambda() && ! is_dir($this->getCacheDir())) {
-            $this->prepareCacheDir(parent::getCacheDir(), $this->getCacheDir());
+        if ($this->isLambda()) {
+            $this->mountOverlay($this->getProjectDir() . '/var', '/tmp/var');
         }
 
         return parent::boot();
     }
 
-    protected function prepareCacheDir(string $staticCacheDir, string $tempCacheDir): void
+    protected function mountOverlay(string $lowerdir, string $upperdir): void
     {
-        $startTime = microtime(true);
-
-        $filesystem = new Filesystem;
-        $filesystem->mkdir($tempCacheDir);
-
-        foreach (scandir($staticCacheDir, SCANDIR_SORT_NONE) as $item) {
-            if (in_array($item, ['.', '..'])) {
-                continue;
-            }
-
-            // the pools folder needs to be writable so mirror it
-            if ($item === 'pools') {
-                $filesystem->mirror("$staticCacheDir/$item", "$tempCacheDir/$item");
-                continue;
-            }
-
-            // symlink all folders other folders
-            // this is especially important with the Container* folder since it uses require_once statements
-            if (is_dir("$staticCacheDir/$item")) {
-                $filesystem->symlink("$staticCacheDir/$item", "$tempCacheDir/$item");
-                continue;
-            }
-
-            // and copy all other files, i had intermediate problems when linking them
-            $filesystem->copy("$staticCacheDir/$item", "$tempCacheDir/$item");
+        // I assume that if the upperdir exists, then it is already mounted
+        if (is_dir($upperdir)) {
+            return;
         }
 
-        $this->logToStderr(sprintf(
-            'Symfony cache directory prepared in %s ms.',
-            number_format((microtime(true) - $startTime) * 1000, 2)
+        mkdir($upperdir);
+        shell_exec(sprintf(
+            'mount -t overlayfs -o %s %s',
+            escapeshellarg('lowerdir=' . $lowerdir . ',upperdir=' . $upperdir),
+            escapeshellarg($lowerdir)
         ));
-    }
-
-    /**
-     * This method logs to stderr.
-     *
-     * It must only be used in a lambda environment since all error output will be logged.
-     *
-     * @param string $message The message to log
-     */
-    protected function logToStderr(string $message): void
-    {
-        file_put_contents('php://stderr', date('[c] ') . $message . PHP_EOL, FILE_APPEND);
     }
 }


### PR DESCRIPTION
Through this change I made the entire /var folder writable without needing to copy anything.

It'll even work with all bundles that somehow write into the var folder since there is no detectable difference to a real writable folder, even when accessed though command and overlayfs is heavily tested since it is one of the core components of docker.