### PR TITLE
Add even more tests

### DIFF
--- a/tests/Functional/App/.gitignore
+++ b/tests/Functional/App/.gitignore
@@ -1,5 +1,6 @@
 composer.lock
 symfony.lock
+tmp/
 
 ###> symfony/framework-bundle ###
 /.env.local

--- a/tests/Functional/App/config/services.yaml
+++ b/tests/Functional/App/config/services.yaml
@@ -25,3 +25,7 @@ services:
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
+
+    App\Command\WriteToCacheCommand:
+        arguments:
+            - '@cache.system'

--- a/tests/Functional/App/src/Command/WriteToCacheCommand.php
+++ b/tests/Functional/App/src/Command/WriteToCacheCommand.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace App\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+
+/**
+ * This command tests writing to the system cache.
+ */
+class WriteToCacheCommand extends Command
+{
+    protected static $defaultName = 'write-to-cache';
+
+    /** @var CacheInterface */
+    private $systemCache;
+
+    public function __construct(CacheInterface $systemCache)
+    {
+        $this->systemCache = $systemCache;
+
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->systemCache->get('foo', function () use ($output) {
+            $output->writeln('The cache was empty, writing entry `foo`');
+            return 'Hello world';
+        });
+        $this->systemCache->get('foo', function () {
+            // Just to be sure the cache write did not silently fail above
+            throw new \Exception('The item should have been cached');
+        });
+
+        return 0;
+    }
+}

--- a/tests/Functional/DeployedWithCacheTest.php
+++ b/tests/Functional/DeployedWithCacheTest.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace Bref\SymfonyBridge\Test\Functional;
+
+/**
+ * Test Symfony when it is deployed WITH the `var/cache` directory.
+ */
+class DeployedWithCacheTest extends FunctionalTest
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->composerInstall();
+        $this->clearCache();
+        // In this scenario, the cache is warmed up (and deployed in Lambda)
+        $this->warmupCache();
+    }
+
+    public function test Symfony works(): void
+    {
+        $this->assertCommandIsSuccessful($this->runSymfonyConsole());
+    }
+
+    public function test Symfony does not recompile the container(): void
+    {
+        $symfonyConsole = $this->runSymfonyConsole();
+        $this->assertStringNotContainsString('Symfony is compiling the container', $symfonyConsole->getOutput());
+        $this->assertCompiledContainerExistsInTmp();
+    }
+    public function test that the Symfony system cache can be written to(): void
+    {
+        $symfonyConsole = $this->runSymfonyConsole('write-to-cache');
+        $this->assertCommandIsSuccessful($symfonyConsole);
+        $this->assertStringContainsString('The cache was empty, writing entry `foo`', $symfonyConsole->getOutput());
+
+        // On the second run, the cache should already exist
+        // We make sure here that the cache is actually written to disk
+        // (i.e. that it works instead of silently failing)
+        $symfonyConsole = $this->runSymfonyConsole('write-to-cache');
+        $this->assertCommandIsSuccessful($symfonyConsole);
+        // We check that it does *NOT* contain the message this time
+        $this->assertStringNotContainsString('The cache was empty, writing entry `foo`', $symfonyConsole->getOutput());
+    }
+}

--- a/tests/Functional/DeployedWithCacheTest.php
+++ b/tests/Functional/DeployedWithCacheTest.php
@@ -27,6 +27,7 @@ class DeployedWithCacheTest extends FunctionalTest
         $this->assertStringNotContainsString('Symfony is compiling the container', $symfonyConsole->getOutput());
         $this->assertCompiledContainerExistsInTmp();
     }
+
     public function test that the Symfony system cache can be written to(): void
     {
         $symfonyConsole = $this->runSymfonyConsole('write-to-cache');

--- a/tests/Functional/DeployedWithoutCacheTest.php
+++ b/tests/Functional/DeployedWithoutCacheTest.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace Bref\SymfonyBridge\Test\Functional;
+
+/**
+ * Test Symfony when it is deployed WITHOUT the `var/cache` directory.
+ */
+class DeployedWithoutCacheTest extends FunctionalTest
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->composerInstall();
+        $this->clearCache();
+    }
+
+    public function test Symfony works(): void
+    {
+        $this->assertCommandIsSuccessful($this->runSymfonyConsole());
+    }
+
+    public function test Symfony compiles the container in tmp(): void
+    {
+        $symfonyConsole = $this->runSymfonyConsole();
+        $this->assertStringContainsString('Symfony is compiling the container', $symfonyConsole->getOutput());
+        $this->assertCompiledContainerExistsInTmp();
+
+        // We check that the container is not recompiled again
+        $symfonyConsole = $this->runSymfonyConsole();
+        $this->assertStringNotContainsString('Symfony is compiling the container', $symfonyConsole->getOutput());
+    }
+
+    public function test that the Symfony system cache can be written to(): void
+    {
+        $symfonyConsole = $this->runSymfonyConsole('write-to-cache');
+        $this->assertCommandIsSuccessful($symfonyConsole);
+        $this->assertStringContainsString('The cache was empty, writing entry `foo`', $symfonyConsole->getOutput());
+
+        // On the second run, the cache should already exist
+        // We make sure here that the cache is actually written to disk
+        // (i.e. that it works instead of silently failing)
+        $symfonyConsole = $this->runSymfonyConsole('write-to-cache');
+        $this->assertCommandIsSuccessful($symfonyConsole);
+        // We check that it does *NOT* contain the message this time
+        $this->assertStringNotContainsString('The cache was empty, writing entry `foo`', $symfonyConsole->getOutput());
+    }
+}

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -20,7 +20,7 @@ abstract class FunctionalTest extends TestCase
     {
         parent::setUp();
         // Make sure we start with an empty `/tmp` for each test
-        (new Filesystem())->remove(self::LOCAL_TMP_DIRECTORY);
+        (new Filesystem)->remove(self::LOCAL_TMP_DIRECTORY);
     }
 
     abstract public function test Symfony works(): void;

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -21,6 +21,7 @@ abstract class FunctionalTest extends TestCase
         parent::setUp();
         // Make sure we start with an empty `/tmp` for each test
         (new Filesystem)->remove(self::LOCAL_TMP_DIRECTORY);
+        (new Filesystem)->mkdir(self::LOCAL_TMP_DIRECTORY);
     }
 
     abstract public function test Symfony works(): void;

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -20,7 +20,9 @@ abstract class FunctionalTest extends TestCase
     {
         parent::setUp();
         // Make sure we start with an empty `/tmp` for each test
-        $this->removeTmpPermissions();
+        if (is_dir(self::LOCAL_TMP_DIRECTORY)) {
+            $this->removeTmpPermissions();
+        }
         $filesystem = new Filesystem;
         $filesystem->remove(self::LOCAL_TMP_DIRECTORY);
         $filesystem->mkdir(self::LOCAL_TMP_DIRECTORY);
@@ -127,12 +129,10 @@ abstract class FunctionalTest extends TestCase
             '--rm',
             '-v',
             self::LOCAL_TMP_DIRECTORY . ':/tmp',
-            '--entrypoint',
-            'chmod',
+            '--entrypoint=bash',
             'bref/php-' . $phpVersion,
-            '-R',
-            '777',
-            '/tmp',
+            '-c',
+            'chmod -R 777 /tmp/*',
         ]);
         $chmod->mustRun();
     }

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -20,8 +20,10 @@ abstract class FunctionalTest extends TestCase
     {
         parent::setUp();
         // Make sure we start with an empty `/tmp` for each test
-        (new Filesystem)->remove(self::LOCAL_TMP_DIRECTORY);
-        (new Filesystem)->mkdir(self::LOCAL_TMP_DIRECTORY);
+        $filesystem = new Filesystem;
+        $filesystem->remove(self::LOCAL_TMP_DIRECTORY);
+        $filesystem->mkdir(self::LOCAL_TMP_DIRECTORY);
+        $filesystem->chmod(self::LOCAL_TMP_DIRECTORY, 0777);
     }
 
     abstract public function test Symfony works(): void;


### PR DESCRIPTION
Test that the system cache still works, and more tests when the compiled container already exists.

This should help us cover the scenarios identified in #21.