### PR TITLE
WIP: Use buildDir for the bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ composer req bref/symfony-bridge
 
 ## Usage
 
-You only need to one one small change To quickly setup Symfony to work with Bref.
+You only need to do two small change to quickly setup Symfony to work with Bref.
+
+First change your `src/Kernel.php` like so :
 
 ```diff
 // src/Kernel.php
@@ -31,6 +33,19 @@ use Symfony\Component\Routing\RouteCollectionBuilder;
 + class Kernel extends BrefKernel
 {
     // ...
+```
+
+Then make sure your `serverless.yaml` contains at least the following include/exclude rules
+
+```yaml
+# ...
+package:
+    exclude:
+        - var/**
+    include:
+        - var/cache/prod/**
+        - var/build/prod/**
+#...
 ```
 
 Now you are up and running.

--- a/src/BrefKernel.php
+++ b/src/BrefKernel.php
@@ -13,6 +13,11 @@ abstract class BrefKernel extends Kernel
         return getenv('LAMBDA_TASK_ROOT') !== false;
     }
 
+    public function allowEmptyBuildDir()
+    {
+        return false;
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -23,6 +28,29 @@ abstract class BrefKernel extends Kernel
         }
 
         return parent::getCacheDir();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBuildDir(): string
+    {
+        $buildDir = $this->getProjectDir().'/var/build/'.$this->environment;
+
+        if ($this->isLambda() && !is_dir($buildDir)) {
+            if (!$this->allowEmptyBuildDir()) {
+                throw new \Exception(
+                    'You must warm and deploy the build directory as part of your Lambda package
+                    as this directory is readonly on Lambda.
+                    You can alternatively define the function allowEmptyBuildDir() in your Kernel class
+                    and return "true" if you still want to deploy without a warm build directory.
+                ');
+            }
+
+            return $this->getCacheDir();
+        }
+
+        return $buildDir;
     }
 
     /**


### PR DESCRIPTION
:building_construction: **WIP**  PR to introduce usage of the buildDir feature.

The only thing done here is generating the builded part of the "cache" in a completly different folder (`var/build`) than the cache part (staying in the default `var/cache`).

This allows for a clear separation when on Lambda so that we can copy/symlink only the cache part but keep the build part read-only which avoids unnecessary processing.

TODO : 
- [ ] Add/adapt tests
- [ ] Adapt the README 
- [ ] Check if the build folder is deployed and fallback on `/tmp` or error correctly
- [ ] Test it on real-life apps to see how well it works  