### PR TITLE
Add Bref as require dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     },
     "require": {
         "php": ">=7.3",
+        "bref/bref": "^1.0",
         "symfony/filesystem": "^4.4|^5.0",
         "symfony/http-kernel": "^4.4|^5.0"
     },


### PR DESCRIPTION
Technically, the library does not need Bref to work properly, but most of the time we will use it with. And it allows to only require `bref/symfony-bridge` in composer