### PR TITLE
Update to symfony/filesystem and symfony/http-kernel to allow for use with version 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": ">=7.3",
         "bref/bref": "^1.0",
         "symfony/filesystem": "^4.4|^5.0|^6.0",
-        "symfony/http-kernel": "^4.4|^5.0"
+        "symfony/http-kernel": "^4.4|^5.0|^6.0"
     },
     "require-dev": {
         "mnapoli/hard-mode": "^0.3.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">=7.3",
         "bref/bref": "^1.0",
-        "symfony/filesystem": "^4.4|^5.0",
+        "symfony/filesystem": "^4.4|^5.0|^6.0,
         "symfony/http-kernel": "^4.4|^5.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">=7.3",
         "bref/bref": "^1.0",
-        "symfony/filesystem": "^4.4|^5.0|^6.0,
+        "symfony/filesystem": "^4.4|^5.0|^6.0",
         "symfony/http-kernel": "^4.4|^5.0"
     },
     "require-dev": {

--- a/src/BrefKernel.php
+++ b/src/BrefKernel.php
@@ -3,6 +3,8 @@
 namespace Bref\SymfonyBridge;
 
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Kernel;
 
@@ -46,7 +48,7 @@ abstract class BrefKernel extends Kernel
      *
      * @see https://github.com/brefphp/symfony-bridge/pull/37
      */
-    public function handle($request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
+    public function handle(Request $request, int $type = HttpKernelInterface::MASTER_REQUEST, bool $catch = true): Response
     {
         $this->prepareCacheDir(parent::getCacheDir(), $this->getCacheDir());
 


### PR DESCRIPTION
Creating a new symfony project now means that symfony/http-kernel and symfony/filesystem are locked at version 6.0. I've just added in the option to allow you to install the package with version 6.0 of both packages.