### PR TITLE
Prepare for deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,8 @@ jobs:
       max-parallel: 10
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1']
+        php: ['8.0', '8.1', '8.2']
         sf_version: ['5.2.*', '5.4.*', '6.0.*']
-        exclude:
-          - php: 7.4
-            sf_version: 6.0.*
 
     steps:
       - name: Set up PHP
@@ -45,7 +42,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@2.7.0
         with:
-          php-version: 7.4
+          php-version: 8.0
           coverage: pcov
 
       - name: Checkout code
@@ -56,5 +53,5 @@ jobs:
 
       - name: Run tests
         env:
-          PHP_VERSION: 7.4
+          PHP_VERSION: 8.0
         run: ./vendor/bin/phpunit -v --coverage-text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,5 +53,5 @@ jobs:
 
       - name: Run tests
         env:
-          PHP_VERSION: 8.0
+          PHP_VERSION: '8.0'
         run: ./vendor/bin/phpunit -v --coverage-text

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@2.7.0
         with:
-          php-version: 7.4
+          php-version: 8.0
 
       - name: Download dependencies
         run: composer update --no-interaction --prefer-dist  --no-progress --no-suggest --dev

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "symfony/config": "^5.2|^6.0",
         "symfony/dependency-injection": "^5.2|^6.0",
         "symfony/framework-bundle": "^5.2|^6.0",
+        "symfony/phpunit-bridge": "^6.0",
         "symfony/process": "^5.2|^6.0"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     },
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.0",
         "bref/bref": "^1.2|^2.0",
         "symfony/filesystem": "^5.2|^6.0",
         "symfony/http-kernel": "^5.2|^6.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,4 +14,11 @@
         </whitelist>
     </filter>
 
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+    </listeners>
+
+    <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
+    </php>
 </phpunit>

--- a/src/BrefKernel.php
+++ b/src/BrefKernel.php
@@ -54,7 +54,7 @@ abstract class BrefKernel extends Kernel
      * We also need to prepare the Cache dir in Kernel::boot in case we are in a Console or worker context
      * in which Kernel::handle is not called.
      */
-    public function boot()
+    public function boot(): void
     {
         $this->prepareCacheDir(parent::getCacheDir(), $this->getCacheDir());
         $this->ensureLogDir($this->getLogDir());

--- a/src/HandlerResolver.php
+++ b/src/HandlerResolver.php
@@ -31,7 +31,7 @@ class HandlerResolver implements ContainerInterface
     /**
      * {@inheritDoc}
      */
-    public function get($id)
+    public function get($id): mixed
     {
         $isComposed = strpos($id, ':') !== false;
 

--- a/tests/Functional/App/config/packages/framework.yaml
+++ b/tests/Functional/App/config/packages/framework.yaml
@@ -1,7 +1,7 @@
 framework:
     secret: '%env(APP_SECRET)%'
     #csrf_protection: true
-    #http_method_override: true
+    http_method_override: false
 
     # Enables session support. Note that the session will ONLY be started if you read or write from it.
     # Remove or comment this section to explicitly disable session support.


### PR DESCRIPTION
Hey @mnapoli,

fixes #65

I've looked at dealing with deprecations and I'd like to hear what you think. I've added `symfony/phpunit-bridge` to bring depreaction notices to the surface. As per the [documentation for libraries](https://symfony.com/doc/current/components/phpunit_bridge.html#internal-deprecations) I configured it to trip only on deprecations within the project.

I also added the ` <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>` to improve the output for the deprecations (see screenshots). 
 
![without the testlistener](https://github.com/brefphp/symfony-bridge/assets/668391/0f03c2ad-1e35-44c8-85e3-f76098698ff0)

![with the testlistener](https://github.com/brefphp/symfony-bridge/assets/668391/3de536a0-a4cc-411b-8f30-ab9b754f08b7)

---

Two of the deprecations are simple enough, and I have added the fix in this PR. It should not break BC.
- add void return type to Kernel::boot()
- explicitly set the framework.http_method_override to the future default value of "false"

The final depreaction is a little trickier - it looks like there will be a "mixed" return type on the PSR-11's container::get() interface [link](https://github.com/php-fig/container/pull/48). Since this is not availabel in PHP7.4 I did not fix that. It also occurs in `Bref\Runtime\FileHandlerLocator` which is not part of this library.

Since I'm not sure if you want to add this phpunit-bridge at all, let me know if you want a PR without it.
