### PR TITLE
Align `BrefKernel::handle` method signature with the `Symfony\Component\HttpKernel\HttpKernelInterface`

### DIFF
--- a/src/BrefKernel.php
+++ b/src/BrefKernel.php
@@ -3,6 +3,7 @@
 namespace Bref\SymfonyBridge;
 
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Kernel;
@@ -41,7 +42,7 @@ abstract class BrefKernel extends Kernel
      *
      * @see https://github.com/brefphp/symfony-bridge/pull/37
      */
-    public function handle($request, $type = HttpKernelInterface::MAIN_REQUEST, $catch = true): Response
+    public function handle(Request $request, int $type = HttpKernelInterface::MAIN_REQUEST, bool $catch = true): Response
     {
         $this->prepareCacheDir(parent::getCacheDir(), $this->getCacheDir());
 


### PR DESCRIPTION
This package has a minimum requirement for Symfony 5.4 and therefore we can align the method signature with the [interface](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/HttpKernel/HttpKernelInterface.php). This is no BC-break as PHP allows to remove type declaration on method overrides.