### PR TITLE
Allow deployments in sub directory

### DIFF
--- a/src/HandlerResolver.php
+++ b/src/HandlerResolver.php
@@ -107,12 +107,10 @@ class HandlerResolver implements ContainerInterface
                 ));
             }
 
-            $projectDir = getenv('LAMBDA_TASK_ROOT') ?: null;
-
             // Use the Symfony Runtime component to resolve the closure and get the PSR-11 container
             $options = $_SERVER['APP_RUNTIME_OPTIONS'] ?? [];
-            if ($projectDir) {
-                $options['project_dir'] = $projectDir;
+            if (!isset($options['project_dir'])) {
+                $options['project_dir'] = dirname(__DIR__, 4);
             }
             $runtime = new BrefRuntime($options);
 

--- a/src/HandlerResolver.php
+++ b/src/HandlerResolver.php
@@ -109,7 +109,7 @@ class HandlerResolver implements ContainerInterface
 
             // Use the Symfony Runtime component to resolve the closure and get the PSR-11 container
             $options = $_SERVER['APP_RUNTIME_OPTIONS'] ?? [];
-            if (!isset($options['project_dir'])) {
+            if (! isset($options['project_dir'])) {
                 $options['project_dir'] = dirname(__DIR__, 4);
             }
             $runtime = new BrefRuntime($options);


### PR DESCRIPTION
Correct me if Im wrong. But I dont think it is possible to use this bridge if you deployed your application in a sub-directory. That is because we give the `BrefRuntime` the wrong "project_dir". 

My serverless.yaml includes the following: 

```yaml
provider:
    name: aws
    environment:
        BREF_AUTOLOAD_PATH: '/var/task/app/vendor/autoload.php'
        BREF_LOOP_MAX: 100
        APP_ENV: prod
```


I cannot add the `LAMBDA_TASK_ROOT` environment variable because of AWS does not allow me. I solve this by not relying on that env var to find the project root. Instead I do `$options['project_dir'] = dirname(__DIR__, 4);` which is very similar to what the default `autoload_runtime.php` does. 

```php
$runtime = $_SERVER['APP_RUNTIME'] ?? $_ENV['APP_RUNTIME'] ?? 'Symfony\\Component\\Runtime\\SymfonyRuntime';
$runtime = new $runtime(($_SERVER['APP_RUNTIME_OPTIONS'] ?? $_ENV['APP_RUNTIME_OPTIONS'] ?? []) + [
  'project_dir' => dirname(__DIR__, 1),
]);
```

