### PR TITLE
Require `bref/monolog-bridge`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     "require": {
         "php": ">=8.0",
         "bref/bref": "^1.2|^2.0",
+        "bref/monolog-bridge": "^1.0",
         "symfony/filesystem": "^5.4|^6.0|^7.0",
         "symfony/http-kernel": "^5.4|^6.0|^7.0",
         "symfony/psr-http-message-bridge": "^2.1|^6.4|^7.0",


### PR DESCRIPTION
Make the `
Bref\Monolog\CloudWatchFormatter` class usable in Symfony.

See brefphp/bref#1969